### PR TITLE
use PATH inference instead of full path

### DIFF
--- a/bin/expose-host-agent
+++ b/bin/expose-host-agent
@@ -13,7 +13,7 @@ fi
 
 # Bind the SSH agent unix socket to a TCP socket on the loopback interface
 # This allows processes inside a Docker build to use keys from the agent
-/usr/local/bin/socat tcp4-listen:24249,bind=127.0.0.1,reuseaddr,fork unix:${SSH_AUTH_SOCK} &
+socat tcp4-listen:24249,bind=127.0.0.1,reuseaddr,fork unix:${SSH_AUTH_SOCK} &
 
 # Tear down socat when we exit, either from a signal or by getting to the end of the script
 trap cleanup EXIT


### PR DESCRIPTION
Homebrew default's path to install is `/opt/homebrew/bin/socat`. I think we either use the PATH in mac or something like this "$(brew --prefix)/bin/socat" but this will tie this tool to homebrew but that's the way we recommend this to be installed.